### PR TITLE
FORDRIF-110: Avoid slashes from webform label in GetOrganized filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ about writing changes to this log.
 
 ## [Unreleased]
 
-* Replaced slashes from webform labels in GetOrganized filenames.
+* Sanitized GetOrganized filenames.
   (<https://github.com/OS2Forms/os2forms_get_organized/pull/8>)
 
 ## [1.1.2] 22.06.2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ about writing changes to this log.
 
 ## [Unreleased]
 
+* Replaced slashes from webform labels in GetOrganized filenames.
+  (<https://github.com/OS2Forms/os2forms_get_organized/pull/8>)
+
 ## [1.1.2] 22.06.2023
 
 * Updated GO file naming strategy

--- a/os2forms_get_organized.services.yml
+++ b/os2forms_get_organized.services.yml
@@ -6,4 +6,5 @@ services:
   Drupal\os2forms_get_organized\Helper\ArchiveHelper:
     arguments:
       - '@entity_type.manager'
+      - '@event_dispatcher'
       - '@Drupal\os2forms_get_organized\Helper\Settings'

--- a/src/Helper/ArchiveHelper.php
+++ b/src/Helper/ArchiveHelper.php
@@ -326,6 +326,7 @@ class ArchiveHelper {
     $webformAttachmentElement = $submission->getWebform()->getElement($webformAttachmentElementId);
     $fileContent = WebformEntityPrintAttachment::getFileContent($webformAttachmentElement, $submission);
     $webformLabel = $submission->getWebform()->label();
+    $webformLabel = str_replace('/', '-', $webformLabel);
     $pdfExtension = '.pdf';
 
     if ($webformAttachmentElement['#filename']) {

--- a/src/Helper/ArchiveHelper.php
+++ b/src/Helper/ArchiveHelper.php
@@ -80,9 +80,9 @@ class ArchiveHelper {
    * Constructs an ArchiveHelper object.
    */
   public function __construct(EntityTypeManagerInterface $entityTypeManager, EventDispatcherInterface $eventDispatcher, Settings $settings) {
-      $this->entityTypeManager = $entityTypeManager;
-      $this->eventDispatcher = $eventDispatcher;
-      $this->settings = $settings;
+    $this->entityTypeManager = $entityTypeManager;
+    $this->eventDispatcher = $eventDispatcher;
+    $this->settings = $settings;
   }
 
   /**
@@ -491,14 +491,15 @@ class ArchiveHelper {
   /**
    * Sanitizes filename.
    */
-  private function sanitizeFilename(string $filename): string
-  {
+  private function sanitizeFilename(string $filename): string {
     // @see https://www.drupal.org/node/3032541
-    // We just want to sanitize filename, therefore the empty string in allowed_extensions.
+    // We just want to sanitize filename,
+    // hence the empty string in allowed_extensions.
     $event = new FileUploadSanitizeNameEvent($filename, '');
 
     $this->eventDispatcher->dispatch($event);
 
     return $event->getFilename();
   }
+
 }


### PR DESCRIPTION
https://jira.itkdev.dk/browse/FORDRIF-110

* Replaces potential slashes from webform label before being used in filename generation.