### PR TITLE
SUPP0RT-1184: Allowed os2forms attachment element in handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ about writing changes to this log.
 
 ## [Unreleased]
 
+* Allowed `os2forms_attachment` attachment element.
+
 ## [1.1.3] 04.07.2023
 
 * Sanitized GetOrganized filenames.

--- a/src/Plugin/WebformHandler/GetOrganizedWebformHandler.php
+++ b/src/Plugin/WebformHandler/GetOrganizedWebformHandler.php
@@ -107,7 +107,10 @@ class GetOrganizedWebformHandler extends WebformHandlerBase {
     $form['general']['attachment_element'] = [
       '#type' => 'select',
       '#title' => $this->t('Attachment element'),
-      '#options' => $this->getAvailableElementsByType(['webform_entity_print_attachment:pdf'], $elements),
+      '#options' => $this->getAvailableElementsByType([
+        'webform_entity_print_attachment:pdf',
+        'os2forms_attachment',
+      ], $elements),
       '#default_value' => $this->configuration['general']['attachment_element'] ?? '',
       '#description' => $this->t('Choose the element responsible for creating response attachments.'),
       '#required' => TRUE,


### PR DESCRIPTION
https://jira.itkdev.dk/browse/SUPP0RT-1184

* Allows `os2forms_attachment` element in handler