### PR TITLE
SUPP0RT-1361: Correctly fetch file content

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -123,6 +123,8 @@ jobs:
           composer --no-interaction --working-dir=drupal config repositories.drupal composer https://packages.drupal.org/8
 
           composer --no-interaction --working-dir=drupal config --no-plugins allow-plugins.cweagans/composer-patches true
+          composer --no-interaction --working-dir=drupal config --no-plugins allow-plugins.zaporylie/composer-drupal-optimizations true
+          composer --no-interaction --working-dir=drupal config --no-plugins allow-plugins.simplesamlphp/composer-module-installer true
           # @see https://getcomposer.org/doc/03-cli.md#modifying-extra-values
           composer --no-interaction --working-dir=drupal config --no-plugins --json extra.enable-patching true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ about writing changes to this log.
 
 ## [Unreleased]
 
+* Disallowed `webform_entity_print_attachment:pdf` attachment element.
+* Called correct `getFileContent` method.
+
 ## [1.1.4] 29.09.2023
 
 * Allowed `os2forms_attachment` attachment element.

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "itk-dev/getorganized-api-client-php": "^1.2",
         "drupal/webform": "^6.1",
         "drupal/advancedqueue": "^1.0",
-        "symfony/options-resolver": "^5.4"
+        "symfony/options-resolver": "^5.4",
+        "os2forms/os2forms": "^3.13"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
@@ -51,7 +52,10 @@
     },
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "zaporylie/composer-drupal-optimizations": true,
+            "cweagans/composer-patches": true,
+            "simplesamlphp/composer-module-installer": true
         }
     }
 }

--- a/os2forms_get_organized.info.yml
+++ b/os2forms_get_organized.info.yml
@@ -7,4 +7,5 @@ dependencies:
   - drupal:webform
   - drupal:advancedqueue
   - drupal:webform_entity_print_attachment
+  - drupal:os2forms_attachment
 configure: os2forms_get_organized.admin.settings

--- a/os2forms_get_organized.info.yml
+++ b/os2forms_get_organized.info.yml
@@ -7,5 +7,5 @@ dependencies:
   - drupal:webform
   - drupal:advancedqueue
   - drupal:webform_entity_print_attachment
-  - drupal:os2forms_attachment
+  - os2forms:os2forms_attachment
 configure: os2forms_get_organized.admin.settings

--- a/src/Helper/ArchiveHelper.php
+++ b/src/Helper/ArchiveHelper.php
@@ -5,12 +5,12 @@ namespace Drupal\os2forms_get_organized\Helper;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\Event\FileUploadSanitizeNameEvent;
+use Drupal\os2forms_attachment\Element\AttachmentElement;
 use Drupal\os2forms_get_organized\Exception\ArchivingMethodException;
 use Drupal\os2forms_get_organized\Exception\CitizenArchivingException;
 use Drupal\os2forms_get_organized\Exception\GetOrganizedCaseIdException;
 use Drupal\webform\Entity\WebformSubmission;
 use Drupal\webform_attachment\Element\WebformAttachmentBase;
-use Drupal\webform_entity_print_attachment\Element\WebformEntityPrintAttachment;
 use ItkDev\GetOrganized\Client;
 use ItkDev\GetOrganized\Service\Cases;
 use ItkDev\GetOrganized\Service\Documents;
@@ -334,7 +334,7 @@ class ArchiveHelper {
   private function uploadDocumentToCase(string $caseId, string $webformAttachmentElementId, WebformSubmission $submission, bool $shouldArchiveFiles, bool $shouldBeFinalized): void {
     // Handle main document (the attachment).
     $webformAttachmentElement = $submission->getWebform()->getElement($webformAttachmentElementId);
-    $fileContent = WebformEntityPrintAttachment::getFileContent($webformAttachmentElement, $submission);
+    $fileContent = AttachmentElement::getFileContent($webformAttachmentElement, $submission);
     $webformLabel = $submission->getWebform()->label();
     $webformLabel = str_replace('/', '-', $webformLabel);
     $pdfExtension = '.pdf';

--- a/src/Plugin/WebformHandler/GetOrganizedWebformHandler.php
+++ b/src/Plugin/WebformHandler/GetOrganizedWebformHandler.php
@@ -107,10 +107,7 @@ class GetOrganizedWebformHandler extends WebformHandlerBase {
     $form['general']['attachment_element'] = [
       '#type' => 'select',
       '#title' => $this->t('Attachment element'),
-      '#options' => $this->getAvailableElementsByType([
-        'webform_entity_print_attachment:pdf',
-        'os2forms_attachment',
-      ], $elements),
+      '#options' => $this->getAvailableElementsByType(['os2forms_attachment'], $elements),
       '#default_value' => $this->configuration['general']['attachment_element'] ?? '',
       '#description' => $this->t('Choose the element responsible for creating response attachments.'),
       '#required' => TRUE,


### PR DESCRIPTION
https://leantime.itkdev.dk/#/tickets/showTicket/231

https://jira.itkdev.dk/browse/SUPP0RT-1361

* Fixes call to `getFileContent` to use the one `os2forms_attachment` provides
* Disallows old pdf attachment element.

`os2forms_attachment` is located within `os2forms/os2forms`, hence the composer requirement.