### PR TITLE
6107: Updated os2forms/os2forms requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ about writing changes to this log.
 
 ## [Unreleased]
 
-## [2.1.0] 08.12.2025
+## [2.1.0] 11.12.2025
 
 * Allowed `os2forms/os2forms` `5.x`.
 * Disallowed `os2forms/os2forms` `3.x`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ about writing changes to this log.
 
 ## [Unreleased]
 
+* Allowed `os2forms/os2forms` `5.x`.
+* Disallowed `os2forms/os2forms` `3.x`.
+
 ## [2.0.1] 08.09.2025
 
 * Only attempt archiving when submission is completed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ about writing changes to this log.
 
 ## [Unreleased]
 
+## [2.1.0] 08.12.2025
+
 * Allowed `os2forms/os2forms` `5.x`.
 * Disallowed `os2forms/os2forms` `3.x`.
 
@@ -15,7 +17,7 @@ about writing changes to this log.
 
 * Only attempt archiving when submission is completed.
 
-## [2.0.0] - 2025-05-02
+## [2.0.0] 05.02.2025
 
 * [PR-14](https://github.com/OS2Forms/os2forms_get_organized/pull/14)
   Added support for [Key](https://www.drupal.org/project/key)
@@ -75,7 +77,8 @@ about writing changes to this log.
 
 ## [1.0.0] 29.03.2023
 
-[Unreleased]: https://github.com/OS2Forms/os2forms_get_organized/compare/2.0.1...HEAD
+[Unreleased]: https://github.com/OS2Forms/os2forms_get_organized/compare/2.1.0...HEAD
+[2.1.0]: https://github.com/OS2Forms/os2forms_get_organized/compare/2.0.1...2.1.0
 [2.0.1]: https://github.com/OS2Forms/os2forms_get_organized/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/OS2Forms/os2forms_get_organized/compare/1.4.1...2.0.0
 [1.4.1]: https://github.com/OS2Forms/os2forms_get_organized/compare/1.4.0...1.4.1

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "drupal/key": "^1.20",
         "drupal/webform": "^6.2",
         "itk-dev/getorganized-api-client-php": "^1.2.2",
-        "os2forms/os2forms": "^3.17 || ^4.0",
+        "os2forms/os2forms": "^4.0 || ^5.0",
         "symfony/options-resolver": "^5.4 || ^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/6107

#### Description

* Allow `os2forms`-core `5.x`
* Disallow `os2forms`-core `3.x`


> [!CAUTION]
> The current set of package requirements cannot be installed from scratch. An issue discussing this has been [created](https://github.com/OS2Forms/os2forms/issues/244). We fully expect this to work in already installed installations, hence we ignore failed GitHub Actions right at this moment.



