### PR TITLE
Ensured plain string first arguments for logging

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -161,7 +161,7 @@ jobs:
 
           # Make Drupal 10 compatible
           composer --working-dir=drupal --no-interaction require psr/http-message:^1.0
-          composer --working-dir=drupal --no-interaction require 'mglaman/composer-drupal-lenient'
+          composer --working-dir=drupal --no-interaction require 'mglaman/composer-drupal-lenient':'^1.0'
           composer --working-dir=drupal config --no-plugins --merge --json extra.drupal-lenient.allowed-list '["drupal/coc_forms_auto_export", "drupal/webform_node_element"]'
 
           # Require our module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ about writing changes to this log.
 
 ## [Unreleased]
 
+## [2.1.1] 09.04.2026
+
+* Ensured static strings as first argument for logging calls.
+
 ## [2.1.0] 11.12.2025
 
 * Allowed `os2forms/os2forms` `5.x`.
@@ -77,7 +81,8 @@ about writing changes to this log.
 
 ## [1.0.0] 29.03.2023
 
-[Unreleased]: https://github.com/OS2Forms/os2forms_get_organized/compare/2.1.0...HEAD
+[Unreleased]: https://github.com/OS2Forms/os2forms_get_organized/compare/2.1.1...HEAD
+[2.1.1]: https://github.com/OS2Forms/os2forms_get_organized/compare/2.1.0...2.1.1
 [2.1.0]: https://github.com/OS2Forms/os2forms_get_organized/compare/2.0.1...2.1.0
 [2.0.1]: https://github.com/OS2Forms/os2forms_get_organized/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/OS2Forms/os2forms_get_organized/compare/1.4.1...2.0.0

--- a/src/Plugin/AdvancedQueue/JobType/ArchiveDocument.php
+++ b/src/Plugin/AdvancedQueue/JobType/ArchiveDocument.php
@@ -85,15 +85,15 @@ class ArchiveDocument extends JobTypeBase implements ContainerFactoryPluginInter
 
       try {
         $this->helper->archive($payload['submissionId'], $payload['handlerConfiguration']);
-        $this->submissionLogger->notice($this->t('The submission #@serial was successfully delivered', ['@serial' => $webformSubmission->serial()]), $logger_context);
+        $this->submissionLogger->notice('The submission #@serial was successfully delivered', $logger_context + ['@serial' => $webformSubmission->serial()]);
 
         return JobResult::success();
       }
       catch (\Exception $e) {
-        $this->submissionLogger->error($this->t('The submission #@serial failed (@message)', [
+        $this->submissionLogger->error('The submission #@serial failed (@message)', $logger_context + [
           '@serial' => $webformSubmission->serial(),
           '@message' => $e->getMessage(),
-        ]), $logger_context);
+        ]);
 
         return JobResult::failure($e->getMessage());
       }

--- a/src/Plugin/AdvancedQueue/JobType/ArchiveDocument.php
+++ b/src/Plugin/AdvancedQueue/JobType/ArchiveDocument.php
@@ -85,15 +85,15 @@ class ArchiveDocument extends JobTypeBase implements ContainerFactoryPluginInter
 
       try {
         $this->helper->archive($payload['submissionId'], $payload['handlerConfiguration']);
-        $this->submissionLogger->notice('The submission #@serial was successfully delivered', $logger_context + ['@serial' => $webformSubmission->serial()]);
+        $this->submissionLogger->notice('The submission #@serial was successfully delivered', ['@serial' => $webformSubmission->serial()] + $logger_context);
 
         return JobResult::success();
       }
       catch (\Exception $e) {
-        $this->submissionLogger->error('The submission #@serial failed (@message)', $logger_context + [
+        $this->submissionLogger->error('The submission #@serial failed (@message)', [
           '@serial' => $webformSubmission->serial(),
           '@message' => $e->getMessage(),
-        ]);
+        ] + $logger_context);
 
         return JobResult::failure($e->getMessage());
       }

--- a/src/Plugin/WebformHandler/GetOrganizedWebformHandler.php
+++ b/src/Plugin/WebformHandler/GetOrganizedWebformHandler.php
@@ -285,7 +285,7 @@ class GetOrganizedWebformHandler extends WebformHandlerBase {
       'operation' => 'submission queued',
     ];
 
-    $this->submissionLogger->notice('Added submission #@serial to queue for processing', $logger_context + ['@serial' => $webform_submission->serial()]);
+    $this->submissionLogger->notice('Added submission #@serial to queue for processing', ['@serial' => $webform_submission->serial()] + $logger_context);
   }
 
   /**

--- a/src/Plugin/WebformHandler/GetOrganizedWebformHandler.php
+++ b/src/Plugin/WebformHandler/GetOrganizedWebformHandler.php
@@ -285,7 +285,7 @@ class GetOrganizedWebformHandler extends WebformHandlerBase {
       'operation' => 'submission queued',
     ];
 
-    $this->submissionLogger->notice($this->t('Added submission #@serial to queue for processing', ['@serial' => $webform_submission->serial()]), $logger_context);
+    $this->submissionLogger->notice('Added submission #@serial to queue for processing', $logger_context + ['@serial' => $webform_submission->serial()]);
   }
 
   /**


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/7124

#### Description

* Ensures first argument to logging are static string to avoid unintended translations.

Found by 

```sh
grep -r -- "->\(emergency\|alert\|critical\|error\|warning\|notice\|info\|debug\|log\)([^']" .
```

> [!CAUTION]
> The current set of package requirements cannot be installed from scratch. An issue discussing this has been [created](https://github.com/OS2Forms/os2forms/issues/244). We fully expect this to work in already installed installations, hence we ignore failed GitHub Actions right at this moment.